### PR TITLE
Adjust when to generate cucumber report

### DIFF
--- a/src/main/java/com/qaprosoft/carina/core/foundation/cucumber/CucumberRunner.java
+++ b/src/main/java/com/qaprosoft/carina/core/foundation/cucumber/CucumberRunner.java
@@ -106,8 +106,8 @@ public abstract class CucumberRunner extends AbstractTest {
     @AfterClass
     public void tearDownClass(ITestContext context) throws Exception {
         LOGGER.info("In  @AfterClass tearDownClass");
-        this.testNGCucumberRunner.finish();
         generateCucumberReport();
+        this.testNGCucumberRunner.finish();
     }
 
     /**


### PR DESCRIPTION
Hi folks,

I have adjusted when to generate cucumber report. Cucumber report is generated before trigger event finish of TestNG runner. You can process this report on next step. Example: you can do something with it by the class which implements a ```ConcurrentEventListener```. 
And I think it help this report can be used more flexibly.

Thks. 